### PR TITLE
Escape repo paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,12 @@ function hash(file, cb) {
   }
 }
 
+function escapeShellArg(arg) {
+  return '\'' + arg.replace(/\'/g, "'\\''") + '\'';
+}
+
 function findRev(repo, cb) {
-  var cmd = ['git --git-dir ', path.resolve(repo, '.git'), 'rev-parse', 'HEAD'].join(' ');
+  var cmd = ['git --git-dir ', escapeShellArg(path.resolve(repo, '.git')), 'rev-parse', 'HEAD'].join(' ');
   exec(cmd, function(err, stdout, stderr) {
     if (err) {
       return cb(err);


### PR DESCRIPTION
Prior to this, a repo path with a space in it would cause the git command to fail. This is avoided by simply escaping the path.

I could not quickly contrive an adequate test, so my test methodology was as follows:
1. Clone source to directory with space in it,
   e.g. `git clone <repo> 'gulp audit'`
2. `npm install`
3. `nodeunit test/audit_test.js`
4. Observe failure like the following:
   
   ```
   Error: Command failed: /bin/sh -c git --git-dir  /Users/colin/Source/gulp audito/.git rev-parse HEAD
   git: 'audito/.git' is not a git command. See 'git --help'.
   ```
5. Patch `index.js` as committed
6. `nodeunit test/audit_test.js`
7. Observe test passage
